### PR TITLE
Phase 1 - Semgrep ingest + triage classifier

### DIFF
--- a/shield-claw/src/shieldclaw/__main__.py
+++ b/shield-claw/src/shieldclaw/__main__.py
@@ -7,11 +7,14 @@ Public API:
   - main(argv: list[str] | None = None) -> int
 Depends On:
   - dotenv (load_dotenv)
+  - shieldclaw.ingest (parse_semgrep_json)
   - shieldclaw.orchestrator (Orchestrator)
+  - shieldclaw.triage (classify)
 Used By:
   - Python runtime (python -m shieldclaw)
 Use Cases:
   - SCAN-001 (Run Vulnerability Scan)
+  - SCAN-002 (Ingest and Triage SAST Findings)
 """
 
 from __future__ import annotations
@@ -91,6 +94,16 @@ def validate_run_configuration(args: Namespace) -> None:
         if diff_path.stat().st_size == 0:
             raise CLIValidationError(f"Diff file is empty: {args.diff}")
 
+    semgrep_output: str | None = getattr(args, "semgrep_output", None)
+    if semgrep_output is not None:
+        sp = Path(semgrep_output).expanduser()
+        if not sp.exists():
+            raise CLIValidationError(f"Semgrep output file does not exist: {semgrep_output}")
+        if not sp.is_file():
+            raise CLIValidationError(f"Semgrep output path is not a file: {semgrep_output}")
+        if not sp.stat().st_size:
+            raise CLIValidationError(f"Semgrep output file is empty: {semgrep_output}")
+
     provider = str(args.provider).lower()
     if provider not in _ALLOWED_PROVIDERS:
         raise CLIValidationError(
@@ -103,6 +116,41 @@ def validate_run_configuration(args: Namespace) -> None:
         raise CLIValidationError("Timeout must be a positive integer between 1 and 120.")
 
 
+def _print_triage_summary(semgrep_path: str) -> None:
+    """Ingest a Semgrep report, classify all findings, and print a summary to stderr.
+
+    This is a Phase 1 preview: the findings are not yet plumbed into the
+    orchestrator pipeline (that happens in Phase 2).
+
+    Args:
+        semgrep_path: Filesystem path to the Semgrep ``--json`` output file.
+    """
+    from shieldclaw.exceptions import IngestError
+    from shieldclaw.ingest.semgrep import parse_semgrep_json
+    from shieldclaw.triage.classifier import classify
+
+    try:
+        findings = parse_semgrep_json(Path(semgrep_path))
+    except IngestError as exc:
+        _LOG.error("Failed to ingest Semgrep report: %s", exc.message)
+        return
+
+    triaged = [classify(f) for f in findings]
+
+    print(
+        f"\n[ShieldClaw] Semgrep triage: {len(triaged)} findings\n",
+        file=sys.stderr,
+    )
+    for tf in triaged:
+        verdict_tag = tf.verdict.value
+        print(
+            f"  [{verdict_tag:24s}] {tf.finding.rule_id}\n"
+            f"    {tf.finding.path}:{tf.finding.start_line}  {tf.reason}",
+            file=sys.stderr,
+        )
+    print("", file=sys.stderr)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Construct the top-level CLI parser with a ``run`` subcommand."""
     parser = _ShieldClawArgumentParser(
@@ -112,6 +160,17 @@ def _build_parser() -> argparse.ArgumentParser:
     run = sub.add_parser("run", help="Run the vulnerability scan pipeline.")
     run.add_argument("--target", required=True, help="Path to the repository under test.")
     run.add_argument("--diff", default=None, help="Optional path to a unified diff patch file.")
+    run.add_argument(
+        "--semgrep-output",
+        dest="semgrep_output",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to a Semgrep --json report.  Findings are triaged and printed to "
+            "stderr before the exploit pipeline runs.  Mutually exclusive with --diff "
+            "(both accepted in Phase 1 with a warning; Phase 2 will integrate findings)."
+        ),
+    )
     run.add_argument(
         "--provider",
         default="ollama",
@@ -148,11 +207,24 @@ def main(argv: list[str] | None = None) -> int:
     if args.command != "run":
         parser.error(f"unknown command {args.command!r}")
 
+    # Warn when --diff and --semgrep-output are both supplied.
+    semgrep_output: str | None = getattr(args, "semgrep_output", None)
+    if args.diff is not None and semgrep_output is not None:
+        _LOG.warning(
+            "--diff and --semgrep-output were both supplied.  "
+            "In Phase 1 both are accepted; Phase 2 will integrate findings into the "
+            "pipeline and may change this behaviour."
+        )
+
     try:
         validate_run_configuration(args)
     except CLIValidationError as exc:
         print(exc.message, file=sys.stderr)
         return 1
+
+    # Phase 1: ingest and triage before the exploit pipeline.
+    if semgrep_output is not None:
+        _print_triage_summary(semgrep_output)
 
     try:
         Orchestrator().run(

--- a/shield-claw/src/shieldclaw/exceptions.py
+++ b/shield-claw/src/shieldclaw/exceptions.py
@@ -66,3 +66,7 @@ class SandboxStartError(ShieldClawError):
 
 class DetonationError(ShieldClawError):
     """Raised when controlled execution of a payload fails unexpectedly."""
+
+
+class IngestError(ShieldClawError):
+    """Raised when a SAST report cannot be parsed or is structurally invalid."""

--- a/shield-claw/src/shieldclaw/ingest/__init__.py
+++ b/shield-claw/src/shieldclaw/ingest/__init__.py
@@ -1,0 +1,7 @@
+"""SAST report ingestion: parse external tool output into Finding records."""
+
+from __future__ import annotations
+
+from shieldclaw.ingest.semgrep import parse_semgrep_json
+
+__all__ = ["parse_semgrep_json"]

--- a/shield-claw/src/shieldclaw/ingest/semgrep.py
+++ b/shield-claw/src/shieldclaw/ingest/semgrep.py
@@ -1,0 +1,222 @@
+"""Parse Semgrep JSON output into immutable Finding records.
+
+Semgrep's ``--json`` output schema (v1.x)::
+
+    {
+        "results": [ <result>, ... ],
+        "errors":  [ <error>,  ... ]
+    }
+
+Each result has the shape::
+
+    {
+        "check_id": "python.flask.security.sqli",
+        "path":     "app/views.py",
+        "start":    {"line": 42, "col": 5},
+        "end":      {"line": 42, "col": 77},
+        "extra": {
+            "severity": "ERROR",
+            "message":  "SQL injection ...",
+            "metadata": {"cwe": ["CWE-89: ..."], ...},
+            "metavars": {
+                "$VAR": {"abstract_content": "request.args.get('id')", ...}
+            }
+        }
+    }
+
+Public API
+----------
+- ``parse_semgrep_json(path: Path) -> tuple[Finding, ...]``
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+from uuid import NAMESPACE_URL, uuid5
+
+from shieldclaw.exceptions import IngestError
+from shieldclaw.models import Finding
+
+# Normalise severity strings that Semgrep may emit.
+_SEVERITY_MAP: dict[str, str] = {
+    "INFO": "INFO",
+    "WARNING": "WARNING",
+    "WARN": "WARNING",
+    "ERROR": "ERROR",
+    "CRITICAL": "ERROR",
+}
+
+# Pattern to extract the canonical CWE identifier from a descriptive string such as
+# "CWE-89: Improper Neutralisation of Special Elements ..."
+_CWE_RE = re.compile(r"(CWE-\d+)", re.IGNORECASE)
+
+
+def _extract_cwe_id(raw: str) -> str:
+    """Return the canonical ``CWE-N`` prefix from a descriptive CWE string."""
+    m = _CWE_RE.search(raw)
+    return m.group(1).upper() if m else raw.strip()
+
+
+def _normalise_cwe(raw: object) -> tuple[str, ...]:
+    """Convert ``extra.metadata.cwe`` (str, list, or absent) to a CWE id tuple."""
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        return (_extract_cwe_id(raw),)
+    if isinstance(raw, list):
+        return tuple(_extract_cwe_id(str(item)) for item in raw if str(item).strip())
+    return ()
+
+
+def _normalise_severity(raw: object, rule_id: str) -> str:
+    """Map a raw Semgrep severity string to one of INFO / WARNING / ERROR."""
+    if not isinstance(raw, str):
+        raise IngestError(
+            f"finding '{rule_id}': expected string for extra.severity, got {type(raw).__name__}"
+        )
+    mapped = _SEVERITY_MAP.get(raw.upper())
+    if mapped is None:
+        raise IngestError(
+            f"finding '{rule_id}': unrecognised severity {raw!r}; expected INFO, WARNING, or ERROR"
+        )
+    return mapped
+
+
+def _flatten_metavars(raw: object) -> dict[str, str]:
+    """Flatten ``extra.metavars`` to ``{name: abstract_content}``."""
+    if not isinstance(raw, dict):
+        return {}
+    result: dict[str, str] = {}
+    for name, info in raw.items():
+        if isinstance(info, dict):
+            content = info.get("abstract_content")
+            if isinstance(content, str):
+                result[str(name)] = content
+    return result
+
+
+def _parse_result(raw: Any, idx: int) -> Finding:
+    """Convert a single Semgrep result object to a ``Finding``.
+
+    Args:
+        raw: Parsed JSON object for one result entry.
+        idx: Zero-based index in the results list (used in error messages).
+
+    Raises:
+        IngestError: On any structural or value problem.
+    """
+    if not isinstance(raw, dict):
+        raise IngestError(f"results[{idx}] is not an object")
+
+    def _req(obj: dict[str, Any], key: str, ctx: str) -> Any:
+        if key not in obj:
+            raise IngestError(f"{ctx}: missing required key {key!r}")
+        return obj[key]
+
+    rule_id = _req(raw, "check_id", f"results[{idx}]")
+    if not isinstance(rule_id, str) or not rule_id:
+        raise IngestError(f"results[{idx}].check_id must be a non-empty string")
+
+    path = _req(raw, "path", f"results[{idx}]")
+    if not isinstance(path, str):
+        raise IngestError(f"results[{idx}].path must be a string")
+
+    start = _req(raw, "start", f"results[{idx}]")
+    end = _req(raw, "end", f"results[{idx}]")
+    if not isinstance(start, dict) or not isinstance(end, dict):
+        raise IngestError(f"results[{idx}]: start/end must be objects")
+
+    start_line_raw = _req(start, "line", f"results[{idx}].start")
+    end_line_raw = _req(end, "line", f"results[{idx}].end")
+    if not isinstance(start_line_raw, int) or not isinstance(end_line_raw, int):
+        raise IngestError(f"results[{idx}]: start.line and end.line must be integers")
+    start_line: int = start_line_raw
+    end_line: int = end_line_raw
+
+    extra = _req(raw, "extra", f"results[{idx}]")
+    if not isinstance(extra, dict):
+        raise IngestError(f"results[{idx}].extra must be an object")
+
+    severity = _normalise_severity(extra.get("severity", "WARNING"), rule_id)
+    message_raw = extra.get("message", "")
+    message = str(message_raw) if message_raw is not None else ""
+
+    metadata = extra.get("metadata") or {}
+    cwe = _normalise_cwe(metadata.get("cwe") if isinstance(metadata, dict) else None)
+
+    metavars = _flatten_metavars(extra.get("metavars"))
+
+    try:
+        raw_extra = json.dumps(extra, ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError) as exc:
+        raise IngestError(f"results[{idx}]: could not serialise extra field: {exc}") from exc
+
+    finding_id = uuid5(NAMESPACE_URL, f"{rule_id}:{path}:{start_line}:{end_line}")
+
+    # severity is guaranteed by _normalise_severity to be one of the three literals.
+    from typing import Literal, cast
+
+    return Finding(
+        finding_id=finding_id,
+        rule_id=rule_id,
+        severity=cast(Literal["INFO", "WARNING", "ERROR"], severity),
+        path=path,
+        start_line=start_line,
+        end_line=end_line,
+        message=message,
+        cwe=cwe,
+        metavars=metavars,
+        raw_extra=raw_extra,
+    )
+
+
+def parse_semgrep_json(path: Path) -> tuple[Finding, ...]:
+    """Parse a Semgrep ``--json`` output file into an immutable tuple of Findings.
+
+    Args:
+        path: Filesystem path to the Semgrep JSON report.
+
+    Returns:
+        Tuple of ``Finding`` instances, one per result entry.  May be empty if
+        the report contains no results.
+
+    Raises:
+        IngestError: When the file cannot be read, is not valid JSON, or the
+            Semgrep schema is not satisfied.  Never raises raw ``KeyError``,
+            ``ValueError``, or ``json.JSONDecodeError`` across this boundary.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise IngestError(f"Cannot read Semgrep report {path}: {exc}") from exc
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise IngestError(f"Semgrep report {path} is not valid JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise IngestError(f"Semgrep report {path}: top-level value must be an object")
+
+    if "results" not in data:
+        raise IngestError(f"Semgrep report {path}: missing top-level key 'results'")
+    if "errors" not in data:
+        raise IngestError(f"Semgrep report {path}: missing top-level key 'errors'")
+
+    results = data["results"]
+    if not isinstance(results, list):
+        raise IngestError(f"Semgrep report {path}: 'results' must be a list")
+
+    findings: list[Finding] = []
+    for idx, raw in enumerate(results):
+        try:
+            findings.append(_parse_result(raw, idx))
+        except IngestError:
+            raise
+        except Exception as exc:
+            raise IngestError(f"results[{idx}]: unexpected parse error: {exc}") from exc
+
+    return tuple(findings)

--- a/shield-claw/src/shieldclaw/models.py
+++ b/shield-claw/src/shieldclaw/models.py
@@ -1,7 +1,7 @@
 """
 File:        src/shieldclaw/models.py
 Purpose:     Shared immutable dataclasses representing scan inputs, exploit payloads,
-             container state, and scan results.
+             container state, scan results, and SAST findings with triage verdicts.
 Public API:
   - ContainerStatus (Enum: PENDING, RUNNING, STOPPED, FAILED)
   - ExploitPayload (frozen dataclass: payload_id, raw_code, target_dns, execution_command, language)
@@ -9,21 +9,26 @@ Public API:
   - ScanResult (frozen dataclass: result_id, exit_code, is_vulnerable, pipeline_error,
                 duration_seconds, exploit_payload, container_state)
   - ScanContext (frozen dataclass: target_dir, git_diff_content, docker_compose_content, timestamp)
+  - Finding (frozen dataclass: finding_id, rule_id, severity, path, start_line, end_line,
+             message, cwe, metavars, raw_extra)
+  - TriageVerdict (Enum: DYNAMICALLY_VERIFIABLE, STATIC_ONLY, OUT_OF_SCOPE)
+  - TriagedFinding (frozen dataclass: finding, verdict, reason)
 Depends On:
-  - stdlib only (dataclasses, datetime, enum, uuid)
+  - stdlib only (dataclasses, datetime, enum, typing, uuid)
 Used By:
   - src/shieldclaw/orchestrator.py
   - src/shieldclaw/context/aggregator.py
   - src/shieldclaw/intelligence/base.py
   - src/shieldclaw/intelligence/ollama.py
-  - src/shieldclaw/intelligence/openai_provider.py
-  - src/shieldclaw/intelligence/anthropic_provider.py
   - src/shieldclaw/intelligence/parser.py
   - src/shieldclaw/intelligence/prompts.py
   - src/shieldclaw/sandbox/docker_orchestrator.py
   - src/shieldclaw/reporting/builder.py
+  - src/shieldclaw/ingest/semgrep.py
+  - src/shieldclaw/triage/classifier.py
 Use Cases:
   - SCAN-001 (Run Vulnerability Scan)
+  - SCAN-002 (Ingest and Triage SAST Findings)
 """
 
 from __future__ import annotations
@@ -31,6 +36,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+from typing import Literal
 from uuid import UUID
 
 
@@ -115,3 +121,60 @@ class ScanContext:
     git_diff_content: str
     docker_compose_content: str
     timestamp: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """A single SAST finding produced by ingesting a Semgrep JSON report.
+
+    All fields are immutable.  ``metavars`` is a plain ``dict`` — callers must
+    not mutate it; a future phase will convert it to a ``MappingProxyType``.
+
+    Args:
+        finding_id: Deterministic UUID derived from rule_id + path + line numbers
+            via ``uuid.uuid5(NAMESPACE_URL, ...)``.
+        rule_id: Fully-qualified Semgrep check identifier (e.g. ``python.flask.sqli``).
+        severity: One of ``"INFO"``, ``"WARNING"``, or ``"ERROR"`` (normalised from
+            Semgrep's ``extra.severity`` field).
+        path: File path relative to the scanned repository root.
+        start_line: 1-based line number where the finding starts.
+        end_line: 1-based line number where the finding ends.
+        message: Human-readable description from ``extra.message``.
+        cwe: Tuple of CWE identifiers (e.g. ``("CWE-89",)``); empty when absent.
+        metavars: Flattened map of metavariable name → ``abstract_content`` string.
+        raw_extra: JSON-serialised original ``extra`` field, retained for debugging.
+    """
+
+    finding_id: UUID
+    rule_id: str
+    severity: Literal["INFO", "WARNING", "ERROR"]
+    path: str
+    start_line: int
+    end_line: int
+    message: str
+    cwe: tuple[str, ...]
+    metavars: dict[str, str]
+    raw_extra: str
+
+
+class TriageVerdict(Enum):
+    """Classification of a SAST finding by whether it can be dynamically verified."""
+
+    DYNAMICALLY_VERIFIABLE = "DYNAMICALLY_VERIFIABLE"
+    STATIC_ONLY = "STATIC_ONLY"
+    OUT_OF_SCOPE = "OUT_OF_SCOPE"
+
+
+@dataclass(frozen=True, slots=True)
+class TriagedFinding:
+    """A ``Finding`` annotated with a triage verdict and human-readable reason.
+
+    Args:
+        finding: The underlying SAST finding.
+        verdict: Triage classification produced by the classifier.
+        reason: Short explanation of why this verdict was assigned.
+    """
+
+    finding: Finding
+    verdict: TriageVerdict
+    reason: str

--- a/shield-claw/src/shieldclaw/triage/__init__.py
+++ b/shield-claw/src/shieldclaw/triage/__init__.py
@@ -1,0 +1,7 @@
+"""Deterministic triage classification of SAST findings."""
+
+from __future__ import annotations
+
+from shieldclaw.triage.classifier import classify
+
+__all__ = ["classify"]

--- a/shield-claw/src/shieldclaw/triage/classifier.py
+++ b/shield-claw/src/shieldclaw/triage/classifier.py
@@ -1,0 +1,124 @@
+"""Rule-based triage classifier: maps CWE numbers and rule-id prefixes to verdicts.
+
+Classification order (evaluated top-to-bottom; first match wins):
+
+1. **OUT_OF_SCOPE by rule-id prefix** — rules whose check_id starts with
+   ``dockerfile.``, ``terraform.``, ``kubernetes.``, ``secrets.``, or
+   ``license.`` describe infrastructure or secret-detection concerns that the
+   exploit pipeline cannot verify dynamically.
+
+2. **OUT_OF_SCOPE by severity + CWE absence** — an ``INFO``-severity finding
+   with no CWE attached is informational only; no exploit detonation is useful.
+
+3. **CWE lookup** — the first CWE id in ``finding.cwe`` that exists in
+   ``_CWE_VERDICTS`` determines the verdict.  CWE ids are matched after
+   stripping the ``CWE-`` prefix and normalising to uppercase.
+
+4. **Default fallback** — STATIC_ONLY with an explanatory reason.
+
+Public API
+----------
+- ``classify(finding: Finding) -> TriagedFinding``
+"""
+
+from __future__ import annotations
+
+from shieldclaw.models import Finding, TriagedFinding, TriageVerdict
+
+# ---------------------------------------------------------------------------
+# CWE → verdict map (module-level constant; order is significant only within
+# the dict for documentation purposes — actual priority is handled by the
+# classifier logic above).
+# ---------------------------------------------------------------------------
+_DV = TriageVerdict.DYNAMICALLY_VERIFIABLE
+_SO = TriageVerdict.STATIC_ONLY
+
+_CWE_VERDICTS: dict[str, TriageVerdict] = {
+    # --- Dynamically verifiable ---
+    "CWE-22": _DV,  # Path traversal
+    "CWE-78": _DV,  # OS command injection
+    "CWE-79": _DV,  # Cross-site scripting (XSS)
+    "CWE-89": _DV,  # SQL injection
+    "CWE-94": _DV,  # Code injection
+    "CWE-352": _DV,  # CSRF
+    "CWE-434": _DV,  # Unrestricted file upload
+    "CWE-502": _DV,  # Deserialization of untrusted data
+    "CWE-601": _DV,  # Open redirect
+    "CWE-611": _DV,  # XML external entity (XXE)
+    "CWE-918": _DV,  # Server-side request forgery (SSRF)
+    # --- Static analysis only ---
+    "CWE-259": _SO,  # Use of hard-coded password
+    "CWE-321": _SO,  # Use of hard-coded cryptographic key
+    "CWE-326": _SO,  # Inadequate encryption strength
+    "CWE-327": _SO,  # Use of broken or risky cryptographic algorithm
+    "CWE-328": _SO,  # Use of weak hash
+    "CWE-330": _SO,  # Use of insufficiently random values
+    "CWE-798": _SO,  # Use of hard-coded credentials
+}
+
+# Rule-id prefix patterns that are always out of scope.
+_OUT_OF_SCOPE_PREFIXES: tuple[str, ...] = (
+    "dockerfile.",
+    "terraform.",
+    "kubernetes.",
+    "secrets.",
+    "license.",
+)
+
+
+def classify(finding: Finding) -> TriagedFinding:
+    """Classify a ``Finding`` into one of three triage verdicts.
+
+    The classification is **pure** and **deterministic** — the same input always
+    produces the same output.  No network calls, no LLM inference, no I/O.
+
+    Classification order (see module docstring for full rationale):
+
+    1. Out-of-scope rule-id prefixes.
+    2. INFO severity with no CWE.
+    3. CWE lookup in ``_CWE_VERDICTS``.
+    4. Default STATIC_ONLY fallback.
+
+    Args:
+        finding: The SAST finding to classify.
+
+    Returns:
+        A ``TriagedFinding`` with the assigned verdict and a short reason string.
+    """
+    rule_lower = finding.rule_id.lower()
+
+    # Step 1: out-of-scope by rule-id prefix.
+    for prefix in _OUT_OF_SCOPE_PREFIXES:
+        if rule_lower.startswith(prefix):
+            return TriagedFinding(
+                finding=finding,
+                verdict=TriageVerdict.OUT_OF_SCOPE,
+                reason=f"rule-id starts with {prefix!r}; infrastructure/secret scan out of scope",
+            )
+
+    # Step 2: INFO severity with no CWE.
+    if finding.severity == "INFO" and not finding.cwe:
+        return TriagedFinding(
+            finding=finding,
+            verdict=TriageVerdict.OUT_OF_SCOPE,
+            reason="INFO severity with no CWE; informational only",
+        )
+
+    # Step 3: CWE lookup — first CWE that maps wins.
+    for cwe_raw in finding.cwe:
+        # Normalise "CWE-89: description" → "CWE-89"
+        cwe_key = cwe_raw.split(":")[0].strip().upper()
+        verdict = _CWE_VERDICTS.get(cwe_key)
+        if verdict is not None:
+            return TriagedFinding(
+                finding=finding,
+                verdict=verdict,
+                reason=f"{cwe_key} mapped to {verdict.value}",
+            )
+
+    # Step 4: default fallback.
+    return TriagedFinding(
+        finding=finding,
+        verdict=TriageVerdict.STATIC_ONLY,
+        reason="no rule mapped; defaulting to static-only to avoid wasted detonation",
+    )

--- a/shield-claw/tests/fixtures/semgrep_sample.json
+++ b/shield-claw/tests/fixtures/semgrep_sample.json
@@ -1,0 +1,106 @@
+{
+  "results": [
+    {
+      "check_id": "python.flask.security.injection.tainted-sql-string.tainted-sql-string",
+      "path": "app.py",
+      "start": {"line": 42, "col": 14, "offset": 1230},
+      "end":   {"line": 42, "col": 77, "offset": 1293},
+      "extra": {
+        "severity": "ERROR",
+        "message": "User-controlled data flows into a raw SQL string. This is a SQL injection vulnerability.",
+        "metadata": {
+          "cwe": ["CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"],
+          "confidence": "HIGH",
+          "technology": ["flask", "sqlalchemy"]
+        },
+        "metavars": {
+          "$USER_ID": {
+            "abstract_content": "request.args.get('id')",
+            "start": {"line": 42, "col": 55, "offset": 1271},
+            "end":   {"line": 42, "col": 77, "offset": 1293}
+          }
+        }
+      }
+    },
+    {
+      "check_id": "python.flask.security.xss.reflected-xss.reflected-xss",
+      "path": "app.py",
+      "start": {"line": 67, "col": 11, "offset": 1890},
+      "end":   {"line": 67, "col": 55, "offset": 1934},
+      "extra": {
+        "severity": "WARNING",
+        "message": "User input is reflected into the response without escaping. This may allow cross-site scripting.",
+        "metadata": {
+          "cwe": ["CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"],
+          "confidence": "MEDIUM"
+        },
+        "metavars": {
+          "$NAME": {
+            "abstract_content": "request.form['name']",
+            "start": {"line": 67, "col": 32, "offset": 1911},
+            "end":   {"line": 67, "col": 55, "offset": 1934}
+          }
+        }
+      }
+    },
+    {
+      "check_id": "python.lang.security.audit.hardcoded-password.hardcoded-password",
+      "path": "app.py",
+      "start": {"line": 12, "col": 1, "offset": 210},
+      "end":   {"line": 12, "col": 30, "offset": 239},
+      "extra": {
+        "severity": "ERROR",
+        "message": "Hardcoded password string detected. Extract credentials from environment variables.",
+        "metadata": {
+          "cwe": ["CWE-259: Use of Hard-coded Password"],
+          "confidence": "HIGH"
+        },
+        "metavars": {
+          "$PWD": {
+            "abstract_content": "'supersecret123'",
+            "start": {"line": 12, "col": 15, "offset": 224},
+            "end":   {"line": 12, "col": 30, "offset": 239}
+          }
+        }
+      }
+    },
+    {
+      "check_id": "python.cryptography.security.insecure-hash-functions.insecure-hash-functions",
+      "path": "utils/crypto.py",
+      "start": {"line": 8, "col": 5, "offset": 120},
+      "end":   {"line": 8, "col": 35, "offset": 150},
+      "extra": {
+        "severity": "WARNING",
+        "message": "MD5 is a cryptographically weak hash function. Use SHA-256 or higher.",
+        "metadata": {
+          "cwe": ["CWE-328: Use of Weak Hash"],
+          "confidence": "HIGH"
+        },
+        "metavars": {}
+      }
+    },
+    {
+      "check_id": "python.lang.security.audit.os-system-injection.os-system-injection",
+      "path": "admin/tasks.py",
+      "start": {"line": 33, "col": 4, "offset": 850},
+      "end":   {"line": 33, "col": 52, "offset": 898},
+      "extra": {
+        "severity": "ERROR",
+        "message": "User input passed directly to os.system(). Potential OS command injection.",
+        "metadata": {
+          "cwe": ["CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"],
+          "confidence": "HIGH",
+          "technology": ["os"]
+        },
+        "metavars": {
+          "$CMD": {
+            "abstract_content": "request.json.get('cmd')",
+            "start": {"line": 33, "col": 14, "offset": 860},
+            "end":   {"line": 33, "col": 37, "offset": 883}
+          }
+        }
+      }
+    }
+  ],
+  "errors": []
+}

--- a/shield-claw/tests/test_architecture.py
+++ b/shield-claw/tests/test_architecture.py
@@ -6,7 +6,14 @@ import ast
 from pathlib import Path
 from typing import Final
 
-_FEATURE_MODULES: Final[tuple[str, ...]] = ("context", "intelligence", "sandbox", "reporting")
+_FEATURE_MODULES: Final[tuple[str, ...]] = (
+    "context",
+    "ingest",
+    "intelligence",
+    "reporting",
+    "sandbox",
+    "triage",
+)
 _ALLOWED_SHIELDCLAW_LEAVES: Final[frozenset[str]] = frozenset({"models", "exceptions"})
 
 

--- a/shield-claw/tests/test_ingest_semgrep.py
+++ b/shield-claw/tests/test_ingest_semgrep.py
@@ -1,0 +1,254 @@
+"""Tests for ``shieldclaw.ingest.semgrep.parse_semgrep_json``."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from shieldclaw.exceptions import IngestError
+from shieldclaw.ingest.semgrep import parse_semgrep_json
+from shieldclaw.models import Finding
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "semgrep_sample.json"
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: fixture round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_loads_five_findings() -> None:
+    """The sample fixture must produce exactly five findings."""
+    findings = parse_semgrep_json(_FIXTURE)
+    assert len(findings) == 5
+
+
+def test_findings_are_finding_instances() -> None:
+    """Every item in the result tuple must be a Finding."""
+    findings = parse_semgrep_json(_FIXTURE)
+    assert all(isinstance(f, Finding) for f in findings)
+
+
+def test_sqli_finding_fields(tmp_path: Path) -> None:
+    """SQLi finding: rule_id, path, line numbers, severity, CWE, metavars."""
+    findings = parse_semgrep_json(_FIXTURE)
+    sqli = next(f for f in findings if "sql" in f.rule_id.lower())
+
+    assert sqli.rule_id == ("python.flask.security.injection.tainted-sql-string.tainted-sql-string")
+    assert sqli.path == "app.py"
+    assert sqli.start_line == 42
+    assert sqli.end_line == 42
+    assert sqli.severity == "ERROR"
+    assert "CWE-89" in sqli.cwe
+    assert "$USER_ID" in sqli.metavars
+    assert "request.args.get" in sqli.metavars["$USER_ID"]
+    assert sqli.raw_extra  # non-empty JSON string
+
+
+def test_finding_id_is_deterministic() -> None:
+    """Parsing the same file twice must produce identical finding_ids."""
+    a = parse_semgrep_json(_FIXTURE)
+    b = parse_semgrep_json(_FIXTURE)
+    assert [f.finding_id for f in a] == [f.finding_id for f in b]
+
+
+def test_finding_id_uuid5_derivation() -> None:
+    """finding_id must be uuid5(NAMESPACE_URL, 'rule_id:path:start:end')."""
+    findings = parse_semgrep_json(_FIXTURE)
+    f = findings[0]
+    expected = uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        f"{f.rule_id}:{f.path}:{f.start_line}:{f.end_line}",
+    )
+    assert f.finding_id == expected
+
+
+def test_hardcoded_password_finding() -> None:
+    """Hardcoded-password finding must have CWE-259 and correct severity."""
+    findings = parse_semgrep_json(_FIXTURE)
+    cred = next(f for f in findings if "hardcoded-password" in f.rule_id)
+    assert "CWE-259" in cred.cwe
+    assert cred.severity == "ERROR"
+
+
+def test_weak_hash_finding_has_no_metavars() -> None:
+    """The weak-hash finding has an empty metavars dict (fixture has empty object)."""
+    findings = parse_semgrep_json(_FIXTURE)
+    h = next(f for f in findings if "hash" in f.rule_id.lower())
+    assert h.metavars == {}
+    assert "CWE-328" in h.cwe
+
+
+def test_cmd_injection_finding() -> None:
+    """OS command injection finding must map CWE-78."""
+    findings = parse_semgrep_json(_FIXTURE)
+    cmd = next(f for f in findings if "os-system" in f.rule_id.lower())
+    assert "CWE-78" in cmd.cwe
+    assert cmd.path == "admin/tasks.py"
+
+
+def test_cwe_ids_are_normalised() -> None:
+    """CWE strings must strip the description suffix, leaving only 'CWE-N'."""
+    findings = parse_semgrep_json(_FIXTURE)
+    for f in findings:
+        for cwe in f.cwe:
+            assert cwe.startswith("CWE-"), f"Expected CWE-N, got {cwe!r}"
+            assert ":" not in cwe, f"Description not stripped: {cwe!r}"
+
+
+# ---------------------------------------------------------------------------
+# Severity normalisation
+# ---------------------------------------------------------------------------
+
+
+def _make_report(results: list[dict[str, object]]) -> str:
+    return json.dumps({"results": results, "errors": []})
+
+
+def _minimal_result(
+    *,
+    severity: str = "ERROR",
+    cwe: list[str] | None = None,
+    metavars: dict[str, object] | None = None,
+) -> dict[str, object]:
+    return {
+        "check_id": "test.rule",
+        "path": "x.py",
+        "start": {"line": 1, "col": 1},
+        "end": {"line": 1, "col": 5},
+        "extra": {
+            "severity": severity,
+            "message": "test",
+            "metadata": {"cwe": cwe or []},
+            "metavars": metavars or {},
+        },
+    }
+
+
+def test_severity_warning_accepted(tmp_path: Path) -> None:
+    """WARNING severity is accepted and preserved."""
+    p = tmp_path / "r.json"
+    p.write_text(_make_report([_minimal_result(severity="WARNING")]), encoding="utf-8")
+    (f,) = parse_semgrep_json(p)
+    assert f.severity == "WARNING"
+
+
+def test_severity_info_accepted(tmp_path: Path) -> None:
+    """INFO severity is accepted and preserved."""
+    p = tmp_path / "r.json"
+    p.write_text(_make_report([_minimal_result(severity="INFO")]), encoding="utf-8")
+    (f,) = parse_semgrep_json(p)
+    assert f.severity == "INFO"
+
+
+def test_severity_warn_normalised_to_warning(tmp_path: Path) -> None:
+    """WARN is an alias for WARNING."""
+    p = tmp_path / "r.json"
+    p.write_text(_make_report([_minimal_result(severity="WARN")]), encoding="utf-8")
+    (f,) = parse_semgrep_json(p)
+    assert f.severity == "WARNING"
+
+
+def test_severity_critical_normalised_to_error(tmp_path: Path) -> None:
+    """CRITICAL maps to ERROR."""
+    p = tmp_path / "r.json"
+    p.write_text(_make_report([_minimal_result(severity="CRITICAL")]), encoding="utf-8")
+    (f,) = parse_semgrep_json(p)
+    assert f.severity == "ERROR"
+
+
+def test_unknown_severity_raises(tmp_path: Path) -> None:
+    """An unrecognised severity must raise IngestError."""
+    p = tmp_path / "r.json"
+    p.write_text(_make_report([_minimal_result(severity="BLOCKER")]), encoding="utf-8")
+    with pytest.raises(IngestError, match="unrecognised severity"):
+        parse_semgrep_json(p)
+
+
+# ---------------------------------------------------------------------------
+# CWE normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_cwe_list_input(tmp_path: Path) -> None:
+    """A list of CWE strings is accepted and each normalised."""
+    p = tmp_path / "r.json"
+    p.write_text(
+        _make_report(
+            [_minimal_result(cwe=["CWE-89: SQL Injection", "CWE-20: Improper Input Validation"])]
+        ),
+        encoding="utf-8",
+    )
+    (f,) = parse_semgrep_json(p)
+    assert "CWE-89" in f.cwe
+    assert "CWE-20" in f.cwe
+
+
+def test_cwe_string_input(tmp_path: Path) -> None:
+    """A single CWE string (not a list) is also accepted."""
+    p = tmp_path / "r.json"
+    p.write_text(
+        _make_report([_minimal_result(cwe=["CWE-79: XSS"])]),  # type: ignore[list-item]
+        encoding="utf-8",
+    )
+    (f,) = parse_semgrep_json(p)
+    assert "CWE-79" in f.cwe
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+def test_missing_file_raises(tmp_path: Path) -> None:
+    """A non-existent path raises IngestError."""
+    with pytest.raises(IngestError, match="Cannot read"):
+        parse_semgrep_json(tmp_path / "absent.json")
+
+
+def test_invalid_json_raises(tmp_path: Path) -> None:
+    """Non-JSON content raises IngestError."""
+    p = tmp_path / "bad.json"
+    p.write_text("not-json", encoding="utf-8")
+    with pytest.raises(IngestError, match="not valid JSON"):
+        parse_semgrep_json(p)
+
+
+def test_missing_results_key_raises(tmp_path: Path) -> None:
+    """A top-level object without 'results' raises IngestError."""
+    p = tmp_path / "r.json"
+    p.write_text('{"errors": []}', encoding="utf-8")
+    with pytest.raises(IngestError, match="missing top-level key 'results'"):
+        parse_semgrep_json(p)
+
+
+def test_missing_errors_key_raises(tmp_path: Path) -> None:
+    """A top-level object without 'errors' raises IngestError."""
+    p = tmp_path / "r.json"
+    p.write_text('{"results": []}', encoding="utf-8")
+    with pytest.raises(IngestError, match="missing top-level key 'errors'"):
+        parse_semgrep_json(p)
+
+
+def test_result_missing_check_id_raises(tmp_path: Path) -> None:
+    """A result without check_id raises IngestError."""
+    bad = {
+        "path": "x.py",
+        "start": {"line": 1, "col": 1},
+        "end": {"line": 1, "col": 5},
+        "extra": {"severity": "ERROR", "message": "x", "metadata": {}, "metavars": {}},
+    }
+    p = tmp_path / "r.json"
+    p.write_text(json.dumps({"results": [bad], "errors": []}), encoding="utf-8")
+    with pytest.raises(IngestError, match="check_id"):
+        parse_semgrep_json(p)
+
+
+def test_empty_results_returns_empty_tuple(tmp_path: Path) -> None:
+    """A report with an empty results list returns an empty tuple."""
+    p = tmp_path / "r.json"
+    p.write_text('{"results": [], "errors": []}', encoding="utf-8")
+    assert parse_semgrep_json(p) == ()

--- a/shield-claw/tests/test_triage_classifier.py
+++ b/shield-claw/tests/test_triage_classifier.py
@@ -1,0 +1,232 @@
+"""Tests for ``shieldclaw.triage.classifier.classify``."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+import pytest
+
+from shieldclaw.models import Finding, TriagedFinding, TriageVerdict
+from shieldclaw.triage.classifier import classify
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SEVERITY = Literal["INFO", "WARNING", "ERROR"]
+
+
+def _finding(
+    *,
+    rule_id: str = "test.rule",
+    severity: str = "ERROR",
+    cwe: tuple[str, ...] = (),
+    path: str = "app.py",
+) -> Finding:
+    return Finding(
+        finding_id=uuid.uuid5(uuid.NAMESPACE_URL, f"{rule_id}:{path}:1:1"),
+        rule_id=rule_id,
+        severity=severity,  # type: ignore[arg-type]
+        path=path,
+        start_line=1,
+        end_line=1,
+        message="test finding",
+        cwe=cwe,
+        metavars={},
+        raw_extra="{}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parametrised: 20 findings covering all three verdict buckets
+# ---------------------------------------------------------------------------
+
+_CASES: list[tuple[str, Finding, TriageVerdict]] = [
+    # --- DYNAMICALLY_VERIFIABLE (10) ---
+    (
+        "sqli",
+        _finding(rule_id="python.flask.sqli", cwe=("CWE-89",)),
+        TriageVerdict.DYNAMICALLY_VERIFIABLE,
+    ),
+    (
+        "xss",
+        _finding(rule_id="python.jinja2.xss", cwe=("CWE-79",)),
+        TriageVerdict.DYNAMICALLY_VERIFIABLE,
+    ),
+    (
+        "cmd_injection",
+        _finding(rule_id="python.os.cmd-injection", cwe=("CWE-78",)),
+        TriageVerdict.DYNAMICALLY_VERIFIABLE,
+    ),
+    (
+        "code_injection",
+        _finding(rule_id="python.eval.code-injection", cwe=("CWE-94",)),
+        TriageVerdict.DYNAMICALLY_VERIFIABLE,
+    ),
+    (
+        "ssrf",
+        _finding(rule_id="python.requests.ssrf", cwe=("CWE-918",)),
+        TriageVerdict.DYNAMICALLY_VERIFIABLE,
+    ),
+    (
+        "path_traversal",
+        _finding(rule_id="python.pathlib.traversal", cwe=("CWE-22",)),
+        TriageVerdict.DYNAMICALLY_VERIFIABLE,
+    ),
+    (
+        "csrf",
+        _finding(rule_id="python.flask.csrf", cwe=("CWE-352",)),
+        TriageVerdict.DYNAMICALLY_VERIFIABLE,
+    ),
+    (
+        "xxe",
+        _finding(rule_id="python.xml.xxe", cwe=("CWE-611",)),
+        TriageVerdict.DYNAMICALLY_VERIFIABLE,
+    ),
+    (
+        "deserialization",
+        _finding(rule_id="python.pickle.deser", cwe=("CWE-502",)),
+        TriageVerdict.DYNAMICALLY_VERIFIABLE,
+    ),
+    (
+        "open_redirect",
+        _finding(rule_id="python.flask.redirect", cwe=("CWE-601",)),
+        TriageVerdict.DYNAMICALLY_VERIFIABLE,
+    ),
+    # --- STATIC_ONLY (5) ---
+    (
+        "weak_hash",
+        _finding(rule_id="python.crypto.md5", cwe=("CWE-328",)),
+        TriageVerdict.STATIC_ONLY,
+    ),
+    (
+        "weak_crypto_algo",
+        _finding(rule_id="python.crypto.des", cwe=("CWE-327",)),
+        TriageVerdict.STATIC_ONLY,
+    ),
+    (
+        "insecure_random",
+        _finding(rule_id="python.random.weak", cwe=("CWE-330",)),
+        TriageVerdict.STATIC_ONLY,
+    ),
+    (
+        "hardcoded_creds",
+        _finding(rule_id="python.secrets.hardcoded", cwe=("CWE-798",)),
+        TriageVerdict.STATIC_ONLY,
+    ),
+    (
+        "hardcoded_password",
+        _finding(rule_id="python.password.literal", cwe=("CWE-259",)),
+        TriageVerdict.STATIC_ONLY,
+    ),
+    # --- OUT_OF_SCOPE (5) ---
+    (
+        "dockerfile_rule",
+        _finding(rule_id="dockerfile.security.apt-get-upgrade"),
+        TriageVerdict.OUT_OF_SCOPE,
+    ),
+    (
+        "terraform_rule",
+        _finding(rule_id="terraform.aws.s3-public-access"),
+        TriageVerdict.OUT_OF_SCOPE,
+    ),
+    (
+        "kubernetes_rule",
+        _finding(rule_id="kubernetes.pod-security-context"),
+        TriageVerdict.OUT_OF_SCOPE,
+    ),
+    (
+        "secrets_rule",
+        _finding(rule_id="secrets.aws.access-key"),
+        TriageVerdict.OUT_OF_SCOPE,
+    ),
+    (
+        "info_no_cwe",
+        _finding(rule_id="python.best-practice.info-note", severity="INFO", cwe=()),
+        TriageVerdict.OUT_OF_SCOPE,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "label,finding,expected_verdict",
+    _CASES,
+    ids=[c[0] for c in _CASES],
+)
+def test_classifier_buckets_correctly(
+    label: str, finding: Finding, expected_verdict: TriageVerdict
+) -> None:
+    """Every test case must receive the expected triage verdict."""
+    result = classify(finding)
+    assert isinstance(result, TriagedFinding)
+    assert result.finding is finding
+    assert result.verdict == expected_verdict, (
+        f"[{label}] expected {expected_verdict.value}, got {result.verdict.value}: {result.reason}"
+    )
+
+
+def test_at_least_18_of_20_correctly_bucketed() -> None:
+    """Guard: at least 18 of the 20 parametrised cases must classify correctly."""
+    correct = sum(1 for _, finding, expected in _CASES if classify(finding).verdict == expected)
+    assert correct >= 18, f"Only {correct}/20 findings classified correctly"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for specific classifier rules
+# ---------------------------------------------------------------------------
+
+
+def test_returns_triaged_finding_type() -> None:
+    """classify must always return a TriagedFinding."""
+    result = classify(_finding(cwe=("CWE-89",)))
+    assert isinstance(result, TriagedFinding)
+
+
+def test_finding_reference_preserved() -> None:
+    """The original Finding must be preserved in TriagedFinding.finding."""
+    f = _finding(cwe=("CWE-89",))
+    assert classify(f).finding is f
+
+
+def test_reason_is_non_empty() -> None:
+    """Every classification must produce a non-empty reason string."""
+    for _, f, _ in _CASES:
+        assert classify(f).reason, f"Empty reason for {f.rule_id}"
+
+
+def test_default_fallback_is_static_only() -> None:
+    """A finding with no CWE and no out-of-scope prefix defaults to STATIC_ONLY."""
+    f = _finding(rule_id="python.custom.unknown", severity="WARNING", cwe=())
+    result = classify(f)
+    assert result.verdict == TriageVerdict.STATIC_ONLY
+    assert "no rule mapped" in result.reason
+
+
+def test_info_severity_with_cwe_is_not_out_of_scope() -> None:
+    """INFO + known CWE must NOT be OUT_OF_SCOPE — it gets the CWE-mapped verdict."""
+    f = _finding(rule_id="python.rule", severity="INFO", cwe=("CWE-89",))
+    result = classify(f)
+    # CWE-89 wins over the INFO+no-CWE rule because the rule requires BOTH conditions.
+    assert result.verdict == TriageVerdict.DYNAMICALLY_VERIFIABLE
+
+
+def test_first_matching_cwe_wins() -> None:
+    """When a finding has multiple CWEs the first matching one determines verdict."""
+    # CWE-89 (DV) listed before CWE-328 (SO) — DV must win.
+    f = _finding(cwe=("CWE-89", "CWE-328"))
+    assert classify(f).verdict == TriageVerdict.DYNAMICALLY_VERIFIABLE
+
+
+def test_license_prefix_is_out_of_scope() -> None:
+    """Rules prefixed with 'license.' must be OUT_OF_SCOPE."""
+    f = _finding(rule_id="license.gpl.compliance", cwe=("CWE-89",))
+    result = classify(f)
+    assert result.verdict == TriageVerdict.OUT_OF_SCOPE
+
+
+def test_cwe_with_description_suffix_normalised() -> None:
+    """CWE ids still containing the description suffix must be stripped."""
+    f = _finding(cwe=("CWE-89: SQL Injection (see OWASP Top 10)",))
+    result = classify(f)
+    assert result.verdict == TriageVerdict.DYNAMICALLY_VERIFIABLE


### PR DESCRIPTION
Add Semgrep JSON ingest, deterministic triage classifier, and CLI
--semgrep-output flag.

- Finding / TriageVerdict / TriagedFinding dataclasses in models.py
- IngestError in exceptions.py
- ingest/ package: parse_semgrep_json with CWE normalisation and
  deterministic uuid5 finding_id
- triage/ package: classify() with 4-step rule ordering
- __main__.py: --semgrep-output flag + stderr triage summary
- 53 new tests (22 ingest, 31 triage); test_architecture.py updated

Closes #23